### PR TITLE
[#1] Do not exclude `db/` and `config/` by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,6 @@ AllCops:
     - '**/config.ru'
     - '**/Capfile'
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
     - 'script/**/*'
   DisplayCopNames: true
   DisplayStyleGuide: true


### PR DESCRIPTION
Both directories `db/` and `config/` often contain code that should also be bound to style-guidelines, so I'd vote for for including them by default. If really necessary they can be excluded on a per-project basis.