### PR TITLE
Exclude generated db-schema file by default.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - '**/Capfile'
   Exclude:
     - 'script/**/*'
+    - 'db/schema.rb'
   DisplayCopNames: true
   DisplayStyleGuide: true
 


### PR DESCRIPTION
We should exclude generated files (like the db/schema.rb) by default though!