### PR TITLE
Change the preferred style of defining children of a class or module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,7 +72,7 @@ Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
 
 Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
+  EnforcedStyle: nested
 
 Style/CollectionMethods:
   Enabled: true


### PR DESCRIPTION
This changes the preferred style for defining children of a class or module from _"compact"_ e.g.
```ruby
class Foo::Bar
end
```
to "nested" _(see the docs for the [ClassAndModuleChildren](http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/ClassAndModuleChildren) cop)_
```ruby
module Foo
  class Bar
  end
end
```

Feel free to discard this PR if you already had a discussion this in the past / have good reasons to prefer the `compact`style 🙇 

I personally think using the `compact` is a bad idea which can quickly lead to bad surprises in the behavior of ones code. It feels like dancing on the edge of a knife for the sake of one line / one level of indentation... 😉 

Background: the way Ruby looks up constants when coming to `Foo:::Bar` it assumes the module or class `Foo` exists. This is especially dangerous in Rails, where everything is autoloaded based on `Module.const_missing`.
Depending on **the order things are loaded**, one might accidentally expose constants of a class to other modules, redefine constans or define methods in an area of the code one did not intend to go to 💣 💥 
See for instance [this blogpost](http://blog.honeybadger.io/avoid-these-traps-when-nesting-ruby-modules/) for an example or [this one](http://urbanautomaton.com/blog/2013/08/27/rails-autoloading-hell/) showing a real world example from Rails.

**TL;DR**
The `compact` syntax, especially when mixed with Rails' autoloading, introduces a level of indeterminism that can quickly start shooting oneself into the foot 🔫 
Therefore I'd suggest to stay on top of things via using the `nested` syntax.