### PR TITLE
Remove deprecated cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,6 +96,10 @@ Metrics/BlockLength:
 Metrics/AbcSize:
   Enabled: true
 
-Layout/SpaceInsideBrackets:
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+  AutoCorrect: true
+
+Layout/SpaceInsideReferenceBrackets:
   Enabled: true
   AutoCorrect: true


### PR DESCRIPTION
This removes the deprecated `Layout/SpaceInsideBrackets` cop and add the
two newly introduced ones (that concern the same problem):
`SpaceInsideArrayLiteralBrackets` and `SpaceInsideReferenceBrackets`.

See rubocop's [changelog](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes-2) for details