### PR TITLE
Alternative config for the Style/AndOr 👮‍♀️

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,7 +68,7 @@ Rails/Validation:
   Enabled: true
 
 Style/AndOr:
-  Enabled: true
+  EnforcedStyle: conditionals
 
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining


### PR DESCRIPTION
This is more of a suggestion - or a question whether or not this discussion already happened _(if so, feel free to close this)_ - to change the configuration for the [Style/AndOr](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AndOr) 👮 

The cop is about replacing `and` and `or` with the logical operators `&&` and `||`.

**However**
Even through `and` and `or` have the same logical meaning as their pure logical counterparts, they are not 100% the same: they have a lower precedence! See [this gist](https://gist.github.com/devboxhl/3d87c36c04f6e628d1e366e11d66e966) for some examples of how this affects Ruby code in the wild🌴.

**👨‍🔬 🔬**
Edward and I ran into a scenario today, where we wanted to return early from a private method in a Rails controller, rendering a certain view. See [the method in the PR](https://github.com/bitcrowd/MyCountryTalks/blob/05fd1fc5fabca405cebb6f894a898e890187b28c/app/controllers/survey_controller.rb#L43) and for more context maybe have a look at [this blog post](https://blog.arkency.com/2014/07/4-ways-to-early-return-from-a-rails-controller/) on _"returning early from a controller"_.

```ruby
def participate
  check_if_open { return }
  @survey_form = SurveyForm.new(partnership: partnership)
end

private

def check_if_open
  render :not_started and yield if event.survey_not_started?
  render :closed and yield if event.survey_closed?
end
```

This particular method only works when using `and`. Logical operators would simply return `true` or `false` 😞 

**tl;dr**
While it definitely makes sense to enforce the usage of `&&` and `||` in comparisons - `and` and `or` may even lead to unhappy surprises there 🙈 - there are actually still usecases where one may deliberately want to use the weaker operators to archive something completely different.
I'd therefore suggest to configure the cop to only enforce the logical operators in conditionals.

Moving from 👇 
```ruby
# bad
foo.save and return

# bad
if foo and bar
end

# good
foo.save && return

# good
if foo && bar
end
```

to 👇 
```ruby
# bad
if foo and bar
end

# good
foo.save && return

# good
foo.save and return

# good
if foo && bar
end
```