### PR TITLE
Add staging to the list of known rails envs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,13 @@ Rails/SkipsModelValidations:
 Rails/TimeZone:
   Enabled: true
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - staging
+    - production
+
 Rails/Validation:
   Enabled: true
 


### PR DESCRIPTION
We usually have four rails environments (production, staging, development, test) where only production, development, and test are the default rails-defined environments. There is a new cop which checks for the environment list (https://github.com/rubocop-hq/rubocop/pull/4791) which we need to configure with our additional staging env.