### PR TITLE
Enforce frozen string literal comment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,7 +90,7 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  EnforcedStyle: always
 
 Style/MutableConstant:
   Enabled: true


### PR DESCRIPTION
This enables the [FrozenStringLiteralComment](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment) 👮 to enforce the magic frozen string literal comment in all files. If you haven't see it, it looks like this and is basically meant as a upgrade-help for the upcoming Ruby 3.x releases.
```ruby
# frozen_string_literal: true

class Lemmy
  # things
end
```

Background: I think™ it's already best practice to use this comment but we haven't had it anywhere in the MCT project. It's **hard** for humans to add it, so I'd say it makes sense to have a machine to it for us :v: