### PR TITLE
Remove the AllCops/Include section

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,4 @@
 AllCops:
-  Include:
-    - '**/Gemfile'
-    - '**/Rakefile'
-    - '**/config.ru'
-    - '**/Capfile'
   Exclude:
     - 'node_modules/**/*'
     - 'vendor/bundle/**/*'

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = 'rubocop-autofix'
 
+  spec.add_runtime_dependency 'rubocop', '>= 0.56'
+
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
Somewhere on the way from version `0.55` to `0.56` Rubocop changed the way how file inclusion and exclusion work - [this PR](https://github.com/rubocop-hq/rubocop/pull/5882) is probably the most important one for this.

[This change to the docs](https://github.com/rubocop-hq/rubocop/pull/6134/files#diff-a960393ef2e779af228b9bc133974921R230) summarizes the problem we have with our current configuration on versions +0.55 pretty well: specifying a `AllCops/Include` section **overrides** Rubocop's internal one specified in [defaults.yml](https://github.com/rubocop-hq/rubocop/blob/a6422ff3e43d7d5cafa4969aa4e32b9f488b08b7/config/default.yml).

In our case this leads to Rubocop only inspecting four files (`Gemfile, Rakefile, Capfile, config.ru`) instead of all of the relevant files in the project.

In order to have Rubocop **look at all files again**, we can however simply drop this section from our configuration. I double checked with the above mentioned `default.yml` file: all the files we're including are in by default anyways. So instead of copying over _(and maintaining)_ the huge list from the Rubocop internals, dropping our obsolete list seemed like the better option to me.

To make it more obvious to people working on older Bitcrowd projects updating their dependencies, that this change specifically targets Rubocop versions `>= 0.56` I turned the dev-dependency into a Runtime dependency, so that bundler takes care of things when updating projects.