### PR TITLE
Update list of excluded directories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
     - 'vendor/bundle/**/*'
     - 'script/**/*'
     - 'db/schema.rb'
+    - 'tmp/**/*'
+    - 'storage/**/*'
+    - 'log/**/*'
   DisplayCopNames: true
   DisplayStyleGuide: true
 


### PR DESCRIPTION
This adds the `tmp`, `log` and `storage` directories to the list of ignore directories. Looking at the [default list](https://github.com/rubocop-hq/rubocop/blob/6fdca6def1c87b57dc9f058ba336b349cb907914/.rubocop.yml) **rubocop** already has, they also exclude the `tmp` directory (wondering why we did not keep that 🤔 )

Background: I recently ran into the situation where running `bundle exec rubocop` on a Rails project would take **+3 minutes** *(and 90% of the time for scanning directories)* because of bloated `tmp` and `storage` directories.

Especially in `storage` - as Rails saves all those `ActiveStorage` files there in deeply deeply nested directories, the lookup for Ruby files can take aaaaaaaages 🐌 . Updating the list will hopefully save other people the pain of finding this out 😉 