### PR TITLE
Update changelog to prepare for 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v1.3.0...HEAD
 ### Fixes:
 
 * Put fixes here (in a brief bullet point)
+* Also exclude the `tmp`, `log` and `storage` directories from being inspected.
+  Working on a Rails application, especially the `tmp` directory fills up over time and slows down linting the project enormously. Same goes for the `storage` directory: here rubocop also has to dig through deeply nested folder structures.  
+  Note: rubocop's "default" configuration also ignores the `tmp` directory.
 
 ## `1.3.0` (2018-10-22)
 


### PR DESCRIPTION
Follow-up to my PR on extending the list of excluded directories (#16): this updates the changelog accordingly to prepare for the potential `1.3.1` release.

I actually wanted to include this in the previous PR, but it was merged faster than I expected 😹 