### PR TITLE
[#19] Exclude config ignored?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,5 @@
 AllCops:
   Exclude:
-    - 'node_modules/**/*'
-    - 'vendor/bundle/**/*'
     - 'script/**/*'
     - 'db/schema.rb'
     - 'tmp/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - 'tmp/**/*'
     - 'storage/**/*'
     - 'log/**/*'
-  DisplayCopNames: true
   DisplayStyleGuide: true
 
 Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 AllCops:
+  # Additional exclude patterns for files that should not be analyzed.
+  # These extend the default RuboCop exclude patterns:
+  # https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml
   Exclude:
     - 'script/**/*'
     - 'db/schema.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v1.3.0...HEAD
 ### Potentially breaking changes:
 
 * Put potentially breaking changes here (in a brief bullet point)
+* require a rubocop version >= 0.57.0
+* remove directories rubocop already excludes by default from the AllCops:Exclude list
+  * keeping the existing list now requires to add an `inherit_mode` section into their `.rubocop.yml`:
+
+    ```yml
+    # This will merge the default exclude list with the one from rubocop-bitcrowd
+    inherit_mode:
+      merge:
+        - Exclude
+    ```
 
 ### New features:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To use the configuration in your project create a .rubocop.yml with:
 ```yml
 inherit_gem:
   rubocop-bitcrowd: .rubocop.yml
+
+# Note: skip this if you want to override the default AllCops:Include and AllCops:Exclude list
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
 ```
 
 # Using rubocop-rspec
@@ -36,6 +42,12 @@ inherit_gem:
   rubocop-bitcrowd:
     - .rubocop.yml
     - .rubocop-rspec.yml
+
+# Note: skip this if you want to override the default AllCops:Include and AllCops:Exclude list
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
 ```
 
 ## Autofixing issues

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -11,13 +11,11 @@ Gem::Specification.new do |spec|
   spec.license              = 'MIT'
   spec.post_install_message = <<~HEREDOC
 
-    PLEASE NOTE: as of version 0.57.0 rubocop allows merging its default
-    AllCops:Include and AllCops:Exclude lists with user defined lists.
+    This version of rubocop-bitcrowd no longer overrides RuboCop's AllCops:Exclude list.
+    It only adds extra patterns not included in the defaults.
 
-    Therefore rubocop-bitcrowd is no longer fully overriding AllCops:Exclude,
-    only adding some extra paths.
-
-    If want to keep excluding everthing as before, add this to your .rubocop.yml:
+    Therefore if you want to keep excluding both, the bitcrowd patterns as well as the RuboCop default ones,
+    add this to your .rubocop.yml
     inherit_mode:
       merge:
         - Exclude

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage             = 'https://github.com/bitcrowd/rubocop-bitcrowd'
   spec.license              = 'MIT'
   spec.post_install_message = <<~HEREDOC
+
     PLEASE NOTE: as of version 0.57.0 rubocop allows merging its default
     AllCops:Include and AllCops:Exclude lists with user defined lists.
 
@@ -25,6 +26,7 @@ Gem::Specification.new do |spec|
 
     Cheers!
     Your friends at bitcrowd
+
   HEREDOC
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = 'rubocop-autofix'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.56'
+  spec.add_runtime_dependency 'rubocop', '~> 0.57.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -1,14 +1,31 @@
 Gem::Specification.new do |spec|
-  spec.name          = 'rubocop-bitcrowd'
-  spec.version       = '1.3.0'
-  spec.authors       = ['bitcrowd']
-  spec.email         = ['info@bitcrowd.net']
+  spec.name                 = 'rubocop-bitcrowd'
+  spec.version              = '1.3.0'
+  spec.authors              = ['bitcrowd']
+  spec.email                = ['info@bitcrowd.net']
 
-  spec.summary       = 'The bitcrowd rubocop.yml as a gem.'
-  spec.description   = 'Use this as a quick start to get rubocop with the '\
-                       'settings we use at bitcrowd into your project'
-  spec.homepage      = 'https://github.com/bitcrowd/rubocop-bitcrowd'
-  spec.license       = 'MIT'
+  spec.summary              = 'The bitcrowd rubocop.yml as a gem.'
+  spec.description          = 'Use this as a quick start to get rubocop with the '\
+                              'settings we use at bitcrowd into your project'
+  spec.homepage             = 'https://github.com/bitcrowd/rubocop-bitcrowd'
+  spec.license              = 'MIT'
+  spec.post_install_message = <<~HEREDOC
+    PLEASE NOTE: as of version 0.57.0 rubocop allows merging its default
+    AllCops:Include and AllCops:Exclude lists with user defined lists.
+
+    Therefore rubocop-bitcrowd is no longer fully overriding AllCops:Exclude,
+    only adding some extra paths.
+
+    If want to keep excluding everthing as before, add this to your .rubocop.yml:
+    inherit_mode:
+      merge:
+        - Exclude
+
+    For more details: https://rubocop.readthedocs.io/en/latest/configuration/#merging-arrays-using-inherit_mode
+
+    Cheers!
+    Your friends at bitcrowd
+  HEREDOC
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Quickly threw together some of the things @pmeinhardt and I came up in #19 
- require a rubocop version starting at `0.57.0` in order to be able to use `inherit_merge` to merge configuration with rubocop's defaults
- update our list of `AllCops:Exclude` (again) to only list things not already in rubocop's default list
- add a post install message to tell the users they should take care of the behavior of `AllCops:Exclude`

The post install message is a bit cheap for now and looks like this:

```
❯ gem install rubocop-bitcrowd-1.3.0.gem
Fetching: rubocop-0.57.2.gem (100%)
Successfully installed rubocop-0.57.2
PLEASE NOTE: as of version 0.57.0 rubocop allows merging its default
AllCops:Include and AllCops:Exclude lists with user defined lists.

Therefore rubocop-bitcrowd is no longer fully overriding AllCops:Exclude,
only adding some extra paths.

If want to keep excluding everthing as before, add this to your .rubocop.yml:
inherit_mode:
  merge:
    - Exclude

For more details: https://rubocop.readthedocs.io/en/latest/configuration/#merging-arrays-using-inherit_mode

Cheers!
Your friends at bitcrowd
Successfully installed rubocop-bitcrowd-1.3.0
2 gems installed
```

☝️ open for suggestions on improving it 😉 