### PR TITLE
[#24] Metrics/BlockLength for rake tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,7 +98,7 @@ Metrics/MethodLength:
 
 Metrics/BlockLength:
   Enabled: true
-  ExcludedMethods: ['describe', 'context', 'define', 'factory']
+  ExcludedMethods: ['describe', 'context', 'define', 'factory', 'namespace']
 
 Metrics/AbcSize:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.0.0...HEAD
 ### New features:
 
 * *Put new features here (in a brief bullet point)*
+* Exclude `namespace` method from `Metrics/BlockLength` to support longer namespace definitions in rake tasks.
 
 ### Fixes:
 
@@ -56,7 +57,7 @@ inherit_mode:
 ### Fixes:
 
 * Also exclude the `tmp`, `log` and `storage` directories from being inspected.
-  Working on a Rails application, especially the `tmp` directory fills up over time and slows down linting the project enormously. Same goes for the `storage` directory: here rubocop also has to dig through deeply nested folder structures.  
+  Working on a Rails application, especially the `tmp` directory fills up over time and slows down linting the project enormously. Same goes for the `storage` directory: here rubocop also has to dig through deeply nested folder structures.
   Note: rubocop's "default" configuration also ignores the `tmp` directory.
 
 ## `1.3.0` (2018-10-22)
@@ -121,4 +122,3 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v1.1.0...v1.1.1
 https://github.com/bitcrowd/rubocop-bitcrowd/compare/695fb551bcd1e17a12f80e34c9bbcb842cee35ea...v1.1.1
 
 * First official release
-


### PR DESCRIPTION
Fixes #24 so we can have rake task namespace definitions longer than the usual 25 lines.
