### PR TITLE
Add compartment for documentation cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'log/**/*'
   DisplayStyleGuide: true
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Lint/UselessAccessModifier:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.0...HEAD
 
 * *Put fixes here (in a brief bullet point)*
 
+* Add compartment to `Documentation` cop
+
 ## `2.1.0` (2019-11-29)
 
 https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.0.0...v2.1.0


### PR DESCRIPTION
This fixes the `Warning: no department given for Documentation.` warning for newer rubocop versions.

https://stackoverflow.com/questions/58218587/how-to-disable-warning-no-department-given-for-cop-message-on-running-rubocop
