### PR TITLE
Update to current state of things

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,10 +16,6 @@ Style/Documentation:
 Lint/UselessAccessModifier:
   Enabled: true
 
-Metrics/LineLength:
-  Enabled: true
-  Max: 120
-
 Rails:
   Enabled: true
 
@@ -102,6 +98,10 @@ Metrics/BlockLength:
 
 Metrics/AbcSize:
   Enabled: true
+
+Layout/LineLength:
+  Enabled: true
+  Max: 120
 
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.0...HEAD
 
 * [#31](https://github.com/bitcrowd/rubocop-bitcrowd/pull/31) Fix deprecation warning by moving `LineLength` cop from `Metrics` to `Layout` and lock the Rubocop version to `>= 0.78.0` and `< 0.79`.
 * *Put fixes here (in a brief bullet point)*
+* [#31](https://github.com/bitcrowd/rubocop-bitcrowd/pull/31) Lock down the minimal `rubocop` version we depend on. Similar to [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec) we're only setting the lower boundary now.
 
 ## `2.1.2` (2019-12-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.0...HEAD
 
 ### Fixes:
 
+* [#31](https://github.com/bitcrowd/rubocop-bitcrowd/pull/31) Fix deprecation warning by moving `LineLength` cop from `Metrics` to `Layout` and lock the Rubocop version to `>= 0.78.0` and `< 0.79`.
 * *Put fixes here (in a brief bullet point)*
 
 ## `2.1.2` (2019-12-17)

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
                               'settings we use at bitcrowd into your project'
   spec.homepage             = 'https://github.com/bitcrowd/rubocop-bitcrowd'
   spec.license              = 'MIT'
+
   spec.post_install_message = <<~HEREDOC
 
     This version of rubocop-bitcrowd no longer overrides RuboCop's AllCops:Exclude list.
@@ -32,6 +33,10 @@ Gem::Specification.new do |spec|
   end
   spec.bindir      = 'exe'
   spec.executables = 'rubocop-autofix'
+
+  spec.metadata = {
+    'changelog_uri' => 'https://github.com/bitcrowd/rubocop-bitcrowd/blob/master/CHANGELOG.md'
+  }
 
   spec.add_runtime_dependency 'rubocop', '>= 0.78.0'
 

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = 'exe'
-  spec.executables   = 'rubocop-autofix'
+  spec.bindir      = 'exe'
+  spec.executables = 'rubocop-autofix'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.57'
+  spec.add_runtime_dependency 'rubocop', '~> 0.78.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.bindir      = 'exe'
   spec.executables = 'rubocop-autofix'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.78.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.78.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
**Updates**
- the `LineLength` cop is in a different namespace now (see [changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0780-2019-12-18))
- add changelog location to gem metadata
- change the runtime dependency lock: only require a minimal `rubocop` version

Background to the last item ☝️ : locking the runtime dependency to `rubocop ~> 0.78.0` would have a similar effect, but it would make it harder for us to find out about deprecations, etc. when working on projects. Also, looking at other custom rubocop configurations, this seems to be a valid way to go. Any opinions on that?