### PR TITLE
[#23] Add performance cops

### DIFF
--- a/.rubocop-performance.yml
+++ b/.rubocop-performance.yml
@@ -1,0 +1,1 @@
+require: rubocop-performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.3...HEAD
 
 ### New features:
 
+* [#32](https://github.com/bitcrowd/rubocop-bitcrowd/pull/32) add possibility to include [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance) cops.
 * *Put new features here (in a brief bullet point)*
 
 ### Fixes:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rubocop::Bitcrowd
+# rubocop-bitcrowd 🚓
 
 The bitcrowd rubocop.yml as a gem.
 
@@ -7,8 +7,8 @@ The bitcrowd rubocop.yml as a gem.
 Add this lines to your application's Gemfile:
 
 ```ruby
-gem 'rubocop'
-gem 'rubocop-bitcrowd'
+gem 'rubocop', require: false
+gem 'rubocop-bitcrowd', require: false
 ```
 
 And then execute:
@@ -30,11 +30,12 @@ inherit_mode:
     - Exclude
 ```
 
-# Using rubocop-rspec
+### Using rubocop-rspec
 
-There is also a config file for rubocop-rspec. To use it add rubocop-rspec to your Gemfile.
+There is also a config file for [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec). To use it add rubocop-rspec to your Gemfile.
+
 ```ruby
-  gem 'rubocop-rspec'
+gem 'rubocop-rspec', require: false
 ```
 
 ```yml
@@ -42,6 +43,28 @@ inherit_gem:
   rubocop-bitcrowd:
     - .rubocop.yml
     - .rubocop-rspec.yml
+
+# Note: skip this if you want to override the default AllCops:Include and AllCops:Exclude list
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
+```
+
+### Using rubocop-performance
+
+There is also a config file for [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance). To use it add rubocop-performance to your Gemfile.
+
+```ruby
+gem 'rubocop-performance', require: false
+```
+
+```yml
+inherit_gem:
+  rubocop-bitcrowd:
+    - .rubocop.yml
+    - .rubocop-rspec.yml
+    - .rubocop-performance.yml
 
 # Note: skip this if you want to override the default AllCops:Include and AllCops:Exclude list
 inherit_mode:
@@ -62,13 +85,13 @@ This gem provides a simple script, that can help you with this task:
 4. Run the script (may take a while, when you want to continue working on your project meanwhile run this in a separate checkout): `rubocop-autofix`
 5. Review all commits made by the script and run your tests. You can now drop certain commits of cops you don't want. Often it may make some sense to run the script again with changed settings, since rebasing 100+ commits is no fun.
 
-# Development
+## Development
 
 Any contributions are welcome. If you attempt to change the behavior of this gem it might be wise to open an issue first to discuss the change. Otherwise feel free to open a PR.
 
 Every PR should have a change in the [CHANGELOG](./CHANGELOG.md) file (within the [`master` section](./CHANGELOG.md#master)) briefly outlining the attempted changes.
 
-## Release a new version
+### Release a new version
 
 To release a new version, follow these steps:
 


### PR DESCRIPTION
~~based on previous PR (#31 )~~

This adds a (currently still empty) `rubocop-performance` config meant to be used with the previously extracted [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance) cops. I also updated the README for how to use this configuration.

Up until now I would not know which special configuration we want there, but I thought it makes sense to already have an empty file in place 🤷‍♂ 