### PR TITLE
Allow longer feature specs

### DIFF
--- a/.rubocop-rspec.yml
+++ b/.rubocop-rspec.yml
@@ -12,7 +12,7 @@ RSpec/NestedGroups:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/**/*'
-  Max: 7
+  Max: 20
 
 RSpec/BeEql:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.0...HEAD
 
 ### Potentially breaking changes:
 
+* [#33](https://github.com/bitcrowd/rubocop-bitcrowd/pull/33) increase the max. number of lines we allow for "feature" specs.
 * *Put potentially breaking changes here (in a brief bullet point)*
 
 ### New features:


### PR DESCRIPTION
Even with extracting lots of helpers, feature specs tend to get long if
they go through full "scenarios". Therefore increasing the max. line
length there (as we basically do it for all projects already anyways).

