### PR TITLE
Extract rails cops

### DIFF
--- a/.rubocop-rails.yml
+++ b/.rubocop-rails.yml
@@ -1,0 +1,50 @@
+require: rubocop-rails
+
+Rails/ActionFilter:
+  Enabled: true
+
+Rails/Date:
+  Enabled: true
+
+Rails/Delegate:
+  Enabled: true
+
+Rails/FindBy:
+  Enabled: true
+
+Rails/FindEach:
+  Enabled: true
+
+Rails/HasAndBelongsToMany:
+  Enabled: true
+
+Rails/Output:
+  Enabled: true
+
+Rails/PluralizationGrammar:
+  Enabled: true
+
+Rails/HttpPositionalArguments:
+  Enabled: true
+
+Rails/ReadWriteAttribute:
+  Enabled: true
+
+Rails/ScopeArgs:
+  Enabled: true
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: true
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - staging
+    - production
+
+Rails/Validation:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,58 +16,6 @@ Style/Documentation:
 Lint/UselessAccessModifier:
   Enabled: true
 
-Rails:
-  Enabled: true
-
-Rails/ActionFilter:
-  Enabled: true
-
-Rails/Date:
-  Enabled: true
-
-Rails/Delegate:
-  Enabled: true
-
-Rails/FindBy:
-  Enabled: true
-
-Rails/FindEach:
-  Enabled: true
-
-Rails/HasAndBelongsToMany:
-  Enabled: true
-
-Rails/Output:
-  Enabled: true
-
-Rails/PluralizationGrammar:
-  Enabled: true
-
-Rails/HttpPositionalArguments:
-  Enabled: true
-
-Rails/ReadWriteAttribute:
-  Enabled: true
-
-Rails/ScopeArgs:
-  Enabled: true
-
-Rails/SkipsModelValidations:
-  Enabled: false
-
-Rails/TimeZone:
-  Enabled: true
-
-Rails/UnknownEnv:
-  Environments:
-    - development
-    - test
-    - staging
-    - production
-
-Rails/Validation:
-  Enabled: true
-
 Style/AndOr:
   Enabled: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.3...HEAD
 
 ### Potentially breaking changes:
 
+* [#34](https://github.com/bitcrowd/rubocop-bitcrowd/pull/34) Extract `rails` cops into separate configuration based on [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails), following the modularization of `rubocop` itself.
 * *Put potentially breaking changes here (in a brief bullet point)*
 
 ### New features:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ And then execute:
 
 ## Usage
 
-To use the configuration in your project create a .rubocop.yml with:
+To use the configuration in your project create a `.rubocop.yml` with:
 
 ```yml
 inherit_gem:
@@ -30,40 +30,29 @@ inherit_mode:
     - Exclude
 ```
 
-### Using rubocop-rspec
+### Using other rubocop gems
 
-There is also a config file for [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec). To use it add rubocop-rspec to your Gemfile.
+There are also config files for the other `rubocop` gems:
+* [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails)
+* [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec)
+* [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance)
+
+To use any of them, add the respective gem to your Gemfile:
 
 ```ruby
+gem 'rubocop-rails', require: false
 gem 'rubocop-rspec', require: false
-```
-
-```yml
-inherit_gem:
-  rubocop-bitcrowd:
-    - .rubocop.yml
-    - .rubocop-rspec.yml
-
-# Note: skip this if you want to override the default AllCops:Include and AllCops:Exclude list
-inherit_mode:
-  merge:
-    - Include
-    - Exclude
-```
-
-### Using rubocop-performance
-
-There is also a config file for [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance). To use it add rubocop-performance to your Gemfile.
-
-```ruby
 gem 'rubocop-performance', require: false
 ```
 
+Then include the bitcrowd config in your `.rubocop.yml`:
+
 ```yml
 inherit_gem:
   rubocop-bitcrowd:
     - .rubocop.yml
     - .rubocop-rspec.yml
+    - .rubocop-rails.yml
     - .rubocop-performance.yml
 
 # Note: skip this if you want to override the default AllCops:Include and AllCops:Exclude list

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -12,16 +12,28 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = <<~HEREDOC
 
-    This version of rubocop-bitcrowd no longer overrides RuboCop's AllCops:Exclude list.
-    It only adds extra patterns not included in the defaults.
+    Starting with this version of rubocop-bitcrowd, we are following RuboCop's
+    modularization into separate gems and splitting up our configuration into:
+    - .rubocop.yml
+    - .rubocop-rails.yml
+    - .rubocop-rspec.yml
+    - .rubocop-performance.yml
 
-    Therefore if you want to keep excluding both, the bitcrowd patterns as well as the RuboCop default ones,
-    add this to your .rubocop.yml
-    inherit_mode:
-      merge:
-        - Exclude
+    If you want to include the `rails`, `rspec` or `performance` cops, add the
+    respective gems to your Gemfile:
 
-    For more details: https://rubocop.readthedocs.io/en/latest/configuration/#merging-arrays-using-inherit_mode
+    gem 'rubocop-rails', require: false
+    gem 'rubocop-rspec', require: false
+    gem 'rubocop-performance', require: false
+
+    Add include the bitcrowd specific configuration in your .rubocop.yml
+
+    inherit_gem:
+      rubocop-bitcrowd:
+        - .rubocop.yml
+        - .rubocop-rspec.yml
+        - .rubocop-rails.yml
+        - .rubocop-performance.yml
 
     Cheers!
     Your friends at bitcrowd


### PR DESCRIPTION
As suggested in https://github.com/bitcrowd/rubocop-bitcrowd/pull/32#issuecomment-603719764, this extracts Rails specific cop configuration into a separate `.rubocop-rails.yml` file. This follows rubocop's internal modularization into gems and allows people to use the bitcrowd rules in a similar fashion (e.g. for non-rails projects).

I also updated adapted the post-install message to inform about that.