### PR TITLE
Update rake because of CVE-2020-8130

### DIFF
--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop', '>= 0.78.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
 end


### PR DESCRIPTION
Since it is a development dependency I think it is not a notable for the CHANGELOG.
