### PR TITLE
Prepare 2.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Rubocop-Bitcrowd Changelog
+# Changelog rubocop-bitcrowd
 
 Presented in reverse chronological order.
 
 ## master
 
-https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.0...HEAD
+https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.3...HEAD
 
 *Put high-level summary here before releasing a new version*
 
@@ -22,8 +22,17 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.0...HEAD
 
 ### Fixes:
 
-* [#31](https://github.com/bitcrowd/rubocop-bitcrowd/pull/31) Fix deprecation warning by moving `LineLength` cop from `Metrics` to `Layout` and lock the Rubocop version to `>= 0.78.0` and `< 0.79`.
 * *Put fixes here (in a brief bullet point)*
+
+## `2.1.3` (2020-03-26)
+
+https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.1.3...HEAD
+
+This releases silences some deprecation warnings and locks down the minimal `rubocop` version `rubocop-bitcrowd` depends on.
+
+### Fixes:
+
+* [#31](https://github.com/bitcrowd/rubocop-bitcrowd/pull/31) Fix deprecation warning by moving `LineLength` cop from `Metrics` to `Layout` and lock the Rubocop version to `>= 0.78.0` and `< 0.79`.
 * [#31](https://github.com/bitcrowd/rubocop-bitcrowd/pull/31) Lock down the minimal `rubocop` version we depend on. Similar to [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec) we're only setting the lower boundary now.
 
 ## `2.1.2` (2019-12-17)

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name                 = 'rubocop-bitcrowd'
-  spec.version              = '2.1.2'
+  spec.version              = '2.1.3'
   spec.authors              = ['bitcrowd']
   spec.email                = ['info@bitcrowd.net']
 


### PR DESCRIPTION
Update changelog and version number for the `2.1.3` release (see #35 ).
