### PR TITLE
Replace ExcludedMethods by IgnoredMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,7 +42,7 @@ Metrics/MethodLength:
 
 Metrics/BlockLength:
   Enabled: true
-  ExcludedMethods: ['describe', 'context', 'define', 'factory', 'namespace']
+  IgnoredMethods: ['describe', 'context', 'define', 'factory', 'namespace']
 
 Metrics/AbcSize:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.2.0...HEAD
 
 ### Fixes:
 
+* [#42](https://github.com/bitcrowd/rubocop-bitcrowd/pull/42) Remove deprecation warnings due to `ExcludedMethods` in rubocop >= 1.5.0
+See rubocop/rubocop#9098 and https://github.com/rubocop/rubocop/blob/1e55b1aa5e4c5eaeccad5d61f08b7930ed6bc341/relnotes/v1.5.0.md
 * [#43](https://github.com/bitcrowd/rubocop-bitcrowd/pull/43) Update documentation mentioning the `master` branch, to use `main` instead
 
 ## `2.2.0` (2020-03-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.2.0...HEAD
 
 ### Fixes:
 
-* [#42](https://github.com/bitcrowd/rubocop-bitcrowd/pull/42) Remove deprecation warnings due to `ExcludedMethods` in rubocop >= 1.5.0
+* [#42](https://github.com/bitcrowd/rubocop-bitcrowd/pull/42) Fix deprecation warning by renaming `ExcludedMethods` to `IgnoredMethods` and lock the Rubocop version to `>= 1.5.0`.
 See rubocop/rubocop#9098 and https://github.com/rubocop/rubocop/blob/1e55b1aa5e4c5eaeccad5d61f08b7930ed6bc341/relnotes/v1.5.0.md
 * [#43](https://github.com/bitcrowd/rubocop-bitcrowd/pull/43) Update documentation mentioning the `master` branch, to use `main` instead
 

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
     'changelog_uri' => 'https://github.com/bitcrowd/rubocop-bitcrowd/blob/main/CHANGELOG.md'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.78.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.5.0'
 
   spec.add_development_dependency 'bundler', '>= 2.1.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'


### PR DESCRIPTION
`ExcludedMethods` becomes obsolete in later version
of rubocop, showing warnings.

See https://github.com/rubocop/rubocop/pull/9098
and https://github.com/rubocop/rubocop/blob/1e55b1aa5e4c5eaeccad5d61f08b7930ed6bc341/relnotes/v1.5.0.md

They say:

> Update Metrics/BlockLength and Metrics/MethodLength to use IgnoredMethods instead of ExcludedMethods in configuration. The previous key is retained for backwards compatibility.

Example of the warning shown with `rubocop-bitcrowd@2.2.0` as dependency:

```
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in /Users/agathe/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-bitcrowd-2.2.0/.rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
```