### PR TITLE
Task/rename master to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.2.0...HEAD
 
 ### Fixes:
 
-* [#43](https://github.com/bitcrowd/rubocop-bitcrowd/pull/43) Update documentation mentionning the `master` branch to use `main` instead
+* [#43](https://github.com/bitcrowd/rubocop-bitcrowd/pull/43) Update documentation mentioning the `master` branch, to use `main` instead
 
 ## `2.2.0` (2020-03-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Presented in reverse chronological order.
 
-## master
+## main
 
 https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.2.0...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ https://github.com/bitcrowd/rubocop-bitcrowd/compare/v2.2.0...HEAD
 
 ### Fixes:
 
-* *Put fixes here (in a brief bullet point)*
+* [#43](https://github.com/bitcrowd/rubocop-bitcrowd/pull/43) Update documentation mentionning the `master` branch to use `main` instead
 
 ## `2.2.0` (2020-03-26)
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ This gem provides a simple script, that can help you with this task:
 
 Any contributions are welcome. If you attempt to change the behavior of this gem it might be wise to open an issue first to discuss the change. Otherwise feel free to open a PR.
 
-Every PR should have a change in the [CHANGELOG](./CHANGELOG.md) file (within the [`master` section](./CHANGELOG.md#master)) briefly outlining the attempted changes.
+Every PR should have a change in the [CHANGELOG](./CHANGELOG.md) file (within the [`main` section](./CHANGELOG.md#main)) briefly outlining the attempted changes.
 
 ### Release a new version
 
 To release a new version, follow these steps:
 
-1. update the [CHANGELOG](./CHANGELOG.md) to reflect the new release and prepare a new [`master` section](./CHANGELOG.md#master)
+1. update the [CHANGELOG](./CHANGELOG.md) to reflect the new release and prepare a new [`main` section](./CHANGELOG.md#main)
 2. update the version in `rubocop-bitcrowd.gemspec` according to [semver](https://semver.org/)
 3. commit that change
 4. run `rake release`

--- a/rubocop-bitcrowd.gemspec
+++ b/rubocop-bitcrowd.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.executables = 'rubocop-autofix'
 
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/bitcrowd/rubocop-bitcrowd/blob/master/CHANGELOG.md'
+    'changelog_uri' => 'https://github.com/bitcrowd/rubocop-bitcrowd/blob/main/CHANGELOG.md'
   }
 
   spec.add_runtime_dependency 'rubocop', '>= 0.78.0'


### PR DESCRIPTION
Some parts of the documentation were still mentioning / linking to `master` branch.